### PR TITLE
Update FPS-R method count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,7 +955,7 @@ You tell FPS-R which frame (or position) it's in, and it sculpts a value based o
 modular rhythms, seeded randomness, layered transitions.  
 From that alone, it creates the illusion of thought—without ever thinking.
 
-FPS-R unfolds through two intertwined methods.  
+FPS-R unfolds through three intertwined methods.  
 Each one offers a unique lens—structured pulses that unlock different facets of unpredictability.
   
 


### PR DESCRIPTION
### **User description**
Changed the description to state that FPS-R unfolds through three intertwined methods instead of two, reflecting updated documentation.


___

### **PR Type**
Documentation


___

### **Description**
- Update FPS-R method count from two to three


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update FPS-R method count description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Changed FPS-R method count from "two" to "three" intertwined methods</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/FPSR_Algorithm/pull/43/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

