### PR TITLE
Update documentation for FPS-R time inflation and QS changes

### DIFF
--- a/ANNOUNCEMENTS.md
+++ b/ANNOUNCEMENTS.md
@@ -5,7 +5,7 @@ This file contains major announcements and important updates about the project.
 ---
 
 ### 4 Sep 2025
-Made some changes to FPS-R QS stream outputs. This will affect QS outputs and break output consistency with previous versions.
+Made some changes to FPS-R QS stream outputs. This will affect QS outputs and break output consistency with earlier versions. Pervious versions send the output from both sine wave streams (-1 to 1) to `portable_rand()`. I have normalised thsee to (0 to 1).
 
 ---
 ### 14 August 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
         - **The `portable_rand()` function now utilizes the highest precision baked sine curve (LUT)** for its internal sine calculations, further enhancing its bit-for-bit determinism and robustness across all platforms.
     - All **time-based integer parameters** (e.g., `minHold`, `maxHold`, `reseedInterval`, `periodA`, `periodB`, `periodSwitch`, `streamsOffset`, `quantOffsets`) are now **internally scaled by** `FPSR_INFLATION_FACTOR` within the base algorithms to match the high-resolution `int_frame` timeline. This ensures absolute, bit-for-bit determinism for all modulo and timing calculations.
     - For Quantised Switching (QS), `baseWaveFreq` and `stream2FreqMult` are **internally deflated** by `FPSR_INFLATION_FACTOR` to correctly apply frequencies to the high-resolution `int_frame` timeline, preventing underflow and maintaining deterministic oscillation.
-    - currently only available for C (canonical reference) and Houdini VEX. Will update the ported versions progressively.
+    - currently only available for C (canonical reference). Will update the ported versions progressively.
 
 ---
 ## [2.0.0] - 2025-09-13

--- a/resources/readme/FPSR_Origins_Journal_Reflections.md
+++ b/resources/readme/FPSR_Origins_Journal_Reflections.md
@@ -2662,9 +2662,46 @@ Because there are infinitely many real numbers between any two distinct values, 
 
 Consequently, these rich outputs would only be **estimates** rather than exact, bit-for-bit identical values, thereby **breaking the absolute determinism** that FPS-R is meticulously designed to uphold.
 
+#### Implementing a Frame Multiplier
 _18 August 2025_
-Had a hard time thinking about how frame and frame_multiplier
+Had a hard time thinking about how frame and frame_multiplier. In the end i was convinced that it is necessary for FPS-R's flexibility as a tool.
 
+But I also decided that determinism is a core pillar of FPS-R and must be fiercely protected.
 
+To enable multiplication of the timeline, I changed the wrapper `fpsr_xx_get_details()` to accept a `float` frame, and inside the base function inflate time and all other time-based arguments with a global inflation factor 10^8. This brings float frame numbers into the integer realm. For decimal numbers that go beyond the significance of `1e8` (or `100,000,000`), I decide to truncate by flooring it.  This works well with `SM` and `TM`.
+
+##### The QS Problem with Time Inflation
+The exception to this is `QS`. QS switches between two streams of sine curves. Their speeds are defined by the offending argument `frequency`. Frequency is inversely proportionate to time and frame. The smaller the frequency value, (aka "lower frequency"), the slower the curve oscillations. The higher the frequency, the faster the curve goes.
+
+In other words, as time inflates, the frequency must deflate by the same amount. This means that if the frequency is already a small float value, as all time or frame related values inflate by 100,000,000, my frequency related values will need to multiple themselves by `0.00000001`! After much deliberation, I decided to use the `double` data type to solve this problem. A `double` data type variable can typically hold 15 to 17 decimal digits. This is almost double my current 8 decimal places, so it should be very accurate to bit-for-bit representation.
+I also made sure that the variables in `portable_rand()` are `double`.
+
+##### The Problem of `sin()`
+There is a inherent problem with very small numbers with sine.
+
+Sine travels around a circle, from 0 to 1. When values become very small the point on a circle is really hard to differentiate between very samll steps. Imagine dividing the curve of a unit circle into 100,000,000 steps. After taking a few steps you would hardly appear to be moving. That is somewhat the visual anologue to the problem we face.
+Also when i researched the typical `sine()` function in a programming language, it usually takes 
+
+From my research, the typical implementation of the **sine** function (`sin()`) in programming languages involves several operations, which can vary based on the algorithm used. However, a common approach is to use a Taylor series expansion or a lookup table combined with interpolation. It also involve factorials which involve exponents calculations (for the powers of x).
+
+In total, a typical `sin()` function can involve anywhere from **5 to 15 operations**, depending on the method used and the precision required. More optimized libraries may reduce this further through various techniques.
+
+When using a very small value with `sin()`, the probability of inaccuracies occuring rises, as well as computational inefficiencies arise from increased computation complexity.
+
+##### The Baking Solution
+I managed to find out an solution to this. My solution is to bake the sine curve results into look-up tables once at the beginning of code execution, choosing only one of these precision steps (100, 500, 1000, 4096), with 4096 being the default. 
+
+This "bakes" the result of a single cycle of sine down to a look-up table. Lower-powered applications that can sacrifice accuracy can choose a sparsely sampled level of detail to reduce the one-time sampling process.
+
+From there on, all values will be looked up, and values in-between will be interpolated from the table, making what promised to be intensive calculations laced with risk of inaccuracy into a simple look-up operation.
 
 ---
+## Updated License to be Apache 2.0
+_13 September 2025, Saturday_
+Changed license to Apache 2.0
+
+---
+## Merging LOD Rich features
+_14 September 2025, Sunday_
+I PR and merged the rich output wrapper functions for FPS-R with LOD sine wave look-up into `main`. As of now only the canonical C code has the wrappers.
+


### PR DESCRIPTION
### **User description**
Expanded journal reflections on implementing time inflation and frequency deflation for FPS-R, including technical details on sine curve lookup tables and determinism. Updated ANNOUNCEMENTS.md to clarify QS stream output normalization, and revised CHANGELOG.md to note availability of features only for C reference implementation.


___

### **PR Type**
Documentation


___

### **Description**
- Expanded journal reflections on FPS-R time inflation implementation

- Updated QS stream output normalization clarification

- Revised feature availability notes for implementations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Time Inflation"] --> B["QS Stream Normalization"]
  B --> C["Documentation Updates"]
  C --> D["Implementation Notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ANNOUNCEMENTS.md</strong><dd><code>Clarify QS stream normalization changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ANNOUNCEMENTS.md

<ul><li>Fixed typo "Pervious" to "Previous"<br> <li> Clarified QS stream output normalization from (-1,1) to (0,1)<br> <li> Enhanced explanation of breaking changes impact</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/fpsr/pull/97/files#diff-e60098c11bc2973f1917a1345bfe5b1993bb0430a7f5a3f1fa22a2f136b118b4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update implementation availability status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Updated feature availability note<br> <li> Removed Houdini VEX from supported implementations<br> <li> Limited current support to C reference only</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/fpsr/pull/97/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FPSR_Origins_Journal_Reflections.md</strong><dd><code>Expand technical implementation journal entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/readme/FPSR_Origins_Journal_Reflections.md

<ul><li>Added detailed explanation of frame multiplier implementation<br> <li> Documented QS frequency deflation problem and solution<br> <li> Explained sine curve lookup table baking approach<br> <li> Added license change and LOD rich features merge notes</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/fpsr/pull/97/files#diff-4925f6849a3cf63c050a50c8fd26e9657cac7bced843db79e794132dfe74782b">+39/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

