### PR TITLE
Update terminology to 'behavioural' in FPSR docs

### DIFF
--- a/resources/readme/FPSR_Applications.md
+++ b/resources/readme/FPSR_Applications.md
@@ -58,7 +58,7 @@ Here, randomness is not noise—it’s performance. Modulation becomes motion. H
 > FPS-R contributes phrasing logic that is deterministic yet organic—producing expressive behaviour across AR, robotics, wearables, and musical systems without scripting or simulation overhead.
 
 ## 🕶️ AR/VR and Human-Centered Interaction
-FPS-R augments synthetic perception systems with organic, non-repeating behavioral texture—introducing subtle timing variation, micro-drift, and decision hesitation across gaze, gesture, and stimulus response. In human-centered environments, where uncanny precision breaks realism, FPS-R fills the behavioral gaps between macro-intent and execution nuance.
+FPS-R augments synthetic perception systems with organic, non-repeating behavioural texture—introducing subtle timing variation, micro-drift, and decision hesitation across gaze, gesture, and stimulus response. In human-centered environments, where uncanny precision breaks realism, FPS-R fills the behavioural gaps between macro-intent and execution nuance.
 
 **Use Cases:**
 - Synthetic User Gaze Generation Simulates realistic eye movement patterns (e.g., drift, tremor, micro-saccades) within goal-driven gaze pathways. Enables scalable A/B testing and heatmap analytics without relying on human gaze data.
@@ -66,7 +66,7 @@ FPS-R augments synthetic perception systems with organic, non-repeating behavior
 - Interaction Modeling and Accessibility Testing Simulates varied user attention profiles with tunable randomness—ideal for evaluating interface legibility, interaction timing, and accessibility under distracted, focused, or fatigued conditions.
 
 **FPS-R Strengths Leveraged:**
-- Stateless behavioral texture with deterministic recall
+- Stateless behavioural texture with deterministic recall
 - Micro-variation of motion without logic entanglement
 - Perceptual believability under constraint
 - Realism through irreproducibility—no two gaze paths identical, yet all plausible
@@ -77,7 +77,7 @@ FPS-R augments synthetic perception systems with organic, non-repeating behavior
 As robotics moves from automation to articulation—from machines that complete tasks to agents that participate—FPS-R offers a stateless modulation layer that injects micro-expressivity and intentional ambiguity into motion. Whether idle, transitioning, or deliberating, robots augmented with FPS-R move as if they mean it.
 
 **Use Cases:**
-- Behavioral Texturing for Expressive Motion Applies organic variation to idle gestures, resting postures, or transitional movements. FPS-R modulates wrist angles, finger articulations, and head gaze during macro-controlled behaviors.
+- behavioural Texturing for Expressive Motion Applies organic variation to idle gestures, resting postures, or transitional movements. FPS-R modulates wrist angles, finger articulations, and head gaze during macro-controlled behaviours.
 - Contemplation and Idle Simulation Replaces scripted loops with natural micro-movements. Robots in idle states use FPS-R to animate non-repeating gaze shifts and head posture drifts, projecting intentionality without costly simulations.
 - Deliberation Simulation and Action Hesitation Modulates micro-pauses before actions—suggesting internal weighing of options or non-linear reasoning. FPS-R introduces subtle latency and signal modulation to simulate “thinking before acting.”
 - Non-Repetitive Attention Realignment Drives periodic visual, tactile, or postural scanning of the environment in non-looping patterns—ideal for adaptive agents in surveillance, caregiving, or co-working scenarios.
@@ -160,7 +160,7 @@ Swarms and autonomous coverage systems often fall into deterministic loops—pre
 Ambient and embedded systems often operate with tight constraints—limited memory, low power, real-time requirements. FPS-R introduces expressive modulation into these systems without breaking the bank on logic complexity or storage.
 **🧰 Use Cases:**
 - Non-Static Actuation and Response Patterns Drives motors, LEDs, or buzzers with varied timing and amplitude patterns—creating organic feedback without scripting loops.
-- Stateless Behavioral Synthesis under Constraint Generates expressive, legible behaviour in highly constrained environments: generative art, ambient notification systems, embedded biofeedback devices.
+- Stateless behavioural Synthesis under Constraint Generates expressive, legible behaviour in highly constrained environments: generative art, ambient notification systems, embedded biofeedback devices.
 
 **🔧 FPS-R Strengths Leveraged:**
 - 🎯 Ultra-low memory footprint
@@ -222,7 +222,7 @@ It’s not about what a system should do under load. It’s about what it phrase
 ## 🛡️ Cybersecurity and Adversarial Simulation
 In cybersecurity, attackers often use automated tools to probe systems, and defenders use analytical tools to detect these patterns. The success of both depends on figuring out the "**what**" (the type of attack or defense) and the "**when**" (its timing). While many systems focus on the "what," the "when" is a critical and often overlooked layer of strategy.
 
-FPS-R acts as a deterministic chaos engine for both attackers and defenders, with a unique strength in obfuscating the "when." It generates realistic, layered threat behavior with replayable entropy—ideal for red/team blue team parity, post-mortem forensics, and training under chaos.
+FPS-R acts as a deterministic chaos engine for both attackers and defenders, with a unique strength in obfuscating the "when." It generates realistic, layered threat behaviour with replayable entropy—ideal for red/team blue team parity, post-mortem forensics, and training under chaos.
 
 **The Power of Obfuscating the "When"**
 By introducing a phrased, unpredictable rhythm to defensive or offensive actions, you can gain a significant advantage. An attack or defense that uses a "move-and-hold" rhythm is much harder for automated tools to distinguish from legitimate, human-driven traffic. This "phrasing" can effectively hide your actions in the noise, creating a "moving target defense." An attacker may know what vulnerability to target, but if the window of opportunity is unpredictable, it makes it much harder to execute a successful attack.
@@ -309,7 +309,7 @@ In environments sensitive to market volatility and sequence-dependent decision l
 **Use Cases:**
 - Synthetic Volatility Cycles: Trigger black-swan behaviour (e.g., flash crashes, recovery delays) with controlled escalation logic.
 - Market Regime Switching: Procedurally modulate agent responses between optimism, fear, and deadlock.
-- Seeded Timeline Replay: Reconstruct behavioral sequences for auditor reviews or post-analysis without historical data dependencies.
+- Seeded Timeline Replay: Reconstruct behavioural sequences for auditor reviews or post-analysis without historical data dependencies.
 
 **FPS-R Strengths Leveraged:**
 - Parameterised stress induction
@@ -350,7 +350,7 @@ FPS-R can be used to simulate layered protocol behaviour, infrastructure churn, 
 # 🧠 Part III — Generative Scenario Planning & Speculative Design
 **FPS-R as phrasing logic for emergent futures and cognitive drift.**
 
-This paradigm treats FPS-R as a tool for modeling not what is, but what _could unfold_. It supports systems that explore escalation, imagination, and behavioral inference—shaping timelines that feel plausible, not predictable.
+This paradigm treats FPS-R as a tool for modeling not what is, but what _could unfold_. It supports systems that explore escalation, imagination, and behavioural inference—shaping timelines that feel plausible, not predictable.
 > Here, phrasing becomes foresight—tempo as thought, rhythm as revelation.
 
 ## ⚔️ Game Theory, Politics, and Strategic Modeling
@@ -399,7 +399,7 @@ Rules become porous. Boundaries breathe. Tokens delay or accelerate not by condi
 
 Topic coherence no longer requires memory. It emerges from **timing logic** alone.
 
-**Latent Drift as Procedural Cognition** Most profound of all: FPS-R may define the **shape of synthetic ideas** as they traverse latent space. Between a start vector and an end vector—two concepts, prompts, or goals—FPS-R doesn’t simply interpolate. It generates a **modulated trajectory**, sculpted by jump-hold-drift behaviors, that samples meaning with **compositional curvature**.
+**Latent Drift as Procedural Cognition** Most profound of all: FPS-R may define the **shape of synthetic ideas** as they traverse latent space. Between a start vector and an end vector—two concepts, prompts, or goals—FPS-R doesn’t simply interpolate. It generates a **modulated trajectory**, sculpted by jump-hold-drift behaviours, that samples meaning with **compositional curvature**.
 
 Each waypoint along this arc reflects **conceptual drift** that is not random, but **phrased**. What appears as wandering attention is in fact procedural guidance through token space. In this way, FPS-R encodes **semantic emergence as rhythm**, and unlocks a form of **path-dependent creativity**—where how one moves through latent space _becomes_ what is expressed.
 
@@ -423,15 +423,15 @@ This section offers a glimpse into how FPS-R can perform what is essentially *re
 
 **FPS-R is a deterministic and parameterised mathematical model** with its own internal logic. Its analytical power lies in its ability to model, express, and procedurally generate observed behaviour using structured phrasing patterns.
 
-When researchers identify a behavioral pattern—its rhythm, tempo, or gestural contour—they can attempt to fit it to an FPS-R function. This involves describing the observed pacing and value changes, then seeking a matching FPS-R curve that echoes its motion, inflection, and intervals between holds and jumps.
+When researchers identify a behavioural pattern—its rhythm, tempo, or gestural contour—they can attempt to fit it to an FPS-R function. This involves describing the observed pacing and value changes, then seeking a matching FPS-R curve that echoes its motion, inflection, and intervals between holds and jumps.
 
 This matching process may include:
 - Brute-force search: iterating over combinations of type, seed, and modulation durations (SM and QS)
 - Library matching: browsing existing capsule archives containing predefined FPS-R parameter sets and “performance clips”
 - Manual profiling: fine-tuning modulation parameters until the phrasing structure aligns with the observed event
-- AI-Assisted Inference: Training a specialised FPS-R agent on a wide spectrum of parameter-output pairs to learn the inverse mapping. This enables the creation of a "Behavioral Spectrometer": an intelligent system capable of decomposing observed phenomena into their most likely FPS-R parameters, based on phrasing structure and modulation rhythm.
+- AI-Assisted Inference: Training a specialised FPS-R agent on a wide spectrum of parameter-output pairs to learn the inverse mapping. This enables the creation of a "behavioural Spectrometer": an intelligent system capable of decomposing observed phenomena into their most likely FPS-R parameters, based on phrasing structure and modulation rhythm.
 
-The more aspects of phrasing that align—rhythmic cadence, modulation shape, move/hold balance—the higher the **model confidence**. A short match may be coincidence. A long match suggests behavioral resonance. Once the best fit is found, FPS-R acts as a **generative analog** of the observed phenomenon.
+The more aspects of phrasing that align—rhythmic cadence, modulation shape, move/hold balance—the higher the **model confidence**. A short match may be coincidence. A long match suggests behavioural resonance. Once the best fit is found, FPS-R acts as a **generative analog** of the observed phenomenon.
 
 This fit unlocks a profound capability: procedural *extension* in both temporal directions.
 
@@ -453,7 +453,7 @@ FPS-R offers **procedural insight into system readiness**: How well is a process
 ### 📽️ Implications
 
 - **Narrative Completion**: Fill in missing moments from partial sequences, or extend them both backward and forward with phrasing continuity.
-- **Behavioral Interpolation**: Bridge missing data between moments through semantically plausible inferences.
+- **behavioural Interpolation**: Bridge missing data between moments through semantically plausible inferences.
 - **Agent Forecasting**: Extend a known behaviour into its next probable phrasing, given its expressive momentum.
 - **Forensics & Memory Reconstruction**: Work backwards from outcomes to simulate a rhythmically plausible past.
 
@@ -480,7 +480,112 @@ And because FPS-R generates phrasing deterministically from fixed seeds and sett
 
 
 ---
-## 🔬 Part IV — Scientific Modeling & Emergent Systems Research
+## 🔬 Part IV — Simulation Testing & Digital Twin
+**FPS-R as an Co-Orchestrator of Simulations**
+
+### 🧠 The Value of Temporal Expressiveness in Simulation
+1. Beyond Combinatorics: Into Causality
+Traditional fuzzing or permutation testing treats systems as stateless combinatorial machines. But real-world systems are temporally entangled:
+- A decision signal doesn’t just flip a state—the action ripples outwards, down the chain, affecting dependent systems and sub-systems.
+- Some subsystems **lag**, others **overcorrect**, and some **accumulate tension** before responding.
+
+Insight: bugs emerge not from the combination itself, but from the timing of its propagation.
+
+2. Hold Duration as a Diagnostic Lens
+The indeterministic “hold” before a jump is a diagnostic feature:
+  - It reveals how long a system can tolerate ambiguity.
+  - It exposes race conditions, delayed reactions, and fragile synchrony.
+  - It simulates real-world pacing. In these scenarios, decisions do not occur instantly or in sync, and causality unfolds in a staggered manner.
+
+This is especially relevant in: **Distributed systems**, **Multi-agent coordination**, **UI/UX feedback loops**, **Sensor fusion pipelines**.
+
+3. FPS-R as a Temporal Perturbation Engine
+Where `rand()` hops values aggressively, FPS-R can:
+
+- Hold a state long enough to let subsystems “settle”
+- Then **break** rhythm at expressive, stateless intervals
+- Creating **non-mechanical perturbations** that mimic real-world pacing
+
+This allows us to test:
+- **Resilience to delayed transitions**
+- **behaviour under partial propagation**
+- **Emergent anomalies from staggered causality**
+
+### 🧪 Simulation as Expressive Stress Testing
+A new kind of simulation:
+
+Not just “what happens when everything changes,” but “what happens when some things wait while others jump.”
+
+This is where **edge happenstance** lives:
+- The rare bugs
+- The emergent collapses
+- The expressive failures that only surface when timing and causality misalign
+
+And yes, they’re hard to catch. But FPS-R gives you a grammar to provoke them—not through brute force, but through **expressive pacing**.
+
+| Concept                | Description                                      |
+|------------------------|--------------------------------------------------|
+|Temporal Drift Testing |	Injecting expressive delays to test causal propagation and subsystem lag |
+| Causality-Stagger | Simulation	Modeling how decisions ripple unevenly across a system |
+| Expressive Perturbation	| Using FPS-R to modulate timing, not just values |
+| Hold-then-Break Diagnostics	| Observing system behaviour during expressive delay before state transition |
+
+#### 🧩 Why It Matters
+- **Real-world systems are not stateless**. Even if the test harness is.
+- **Timing is a primary source of bugs.** This is particularly true in distributed, reactive, or human-facing systems.
+- **Expressive entropy uncovers insights that brute-force randomness misses**. It captures and reflects the natural rhythm found in real-world systems.
+
+### 🧠 Digital Twins + FPS-R: A New Layer of Expressive Fidelity
+Digital twins traditionally aim for state mirroring—replicating the physical system’s data, structure, and behaviour in real time. But what’s often missing is expressive timing and causal nuance. That’s where FPS-R enters:
+
+#### 🔄 Traditional Twin Simulation
+- Focuses on state snapshots and deterministic transitions.
+- Often uses rand() or noise for environmental variability.
+- Lacks temporal expressiveness—everything updates in sync or on rigid schedules.
+#### 🎲 FPS-R Augmented Twin Simulation
+- Introduces **frame-persistent randomness** to simulate real-world pacing.
+- Models **delayed reactions, hesitation**, and **non-mechanical drift**.
+- Enables **causality-staggered propagation**—where one subsystem reacts immediately, another lags, and a third overcompensates.
+
+#### 🧪 Applications Across Twin Scenarios
+##### 1. Training Simulations
+- *Use case*: Operator training for complex systems (e.g., power grids, aircraft, logistics).
+- *FPS-R role*: Inject expressive delays to simulate real-world stressors, introducing unpredictable pacing for added realism.  
+- *Why it matters*: This unpredictability enhances realism and prepares trainees for non-ideal rhythms.
+- *Why it matters*: Trainees learn to adapt to non-ideal rhythms, not just idealised transitions.
+
+##### 2. behavioural Testing
+- *Use case*: Testing how systems respond to edge-case scenarios.
+- *FPS-R role*: Modulate timing of input changes—some variables hold, others jump.
+- *Why it matters*: Reveals bugs that only surface under temporal misalignment or **causal lag**.
+
+##### 3. Live Data Observation
+- *Use case*: Monitoring real-time systems via their digital twin.
+- *FPS-R role*: Simulate expressive uncertainty in sensor data or subsystem behaviour.
+- *Why it matters*: It enables operators to clearly differentiate between **mechanical anomalies** and **expressive drift**, which is a subtle yet crucial distinction.
+
+##### 4. Multi-Agent Twin Environments
+- *Use case*: Simulating fleets, swarms, or distributed systems.
+- *FPS-R role*: Introduce global offset drift across agents to prevent deadlocks and rhythmic traps.
+- *Why it matters*: Enhances realism and robustness—agents behave like **individuals**, not clones.
+
+### FPS-R as a Temporal Enrichment Layer
+FPS-R transforms the digital twin, opening doors to:
+- **Emotional simulation** in human-facing twins (e.g., healthcare, education).
+- **Behavioural realism** in training environments.
+- **Edge-case discovery** in complex, causally entangled systems.
+
+
+|Twin Component	| Traditional Approach	| FPS-R Enrichment |
+|---------------|-----------------------|------------------|
+|State Transitions | Deterministic or noisy |	Expressive, frame-persistent randomness
+|Timing Behavior | Rigid or synchronized  | Hesitation, drift, staggered causality
+| Agent Coordination	| Rule-based or optimized	| Emergent offsets, behavioral diversity
+| Edge Case Discovery	| Combinatorial fuzzing	| Temporal perturbation and expressive lag
+
+
+---
+## 🔬 Part V — Scientific Modeling & Emergent Systems Research
 **FPS-R as a deterministic engine for exploring probabilistic worlds.**
 
 ### A Framework for Phrasing, Not Physics: An Important Disclaimer
@@ -527,7 +632,7 @@ Here, the challenge here is for domain users to provide the context to match the
 - **Galaxy Distribution & Intergalactic Voids:** Model the large-scale structure of the universe. An FPS-R output can determine the probability of star formation or matter density within a sector of space. Long "holds" create vast, empty voids, while clustered "jumps" can seed the formation of galactic superclusters.
 
 ## 🧬 Computational Biology & Bioinformatics
-Many biological systems are governed by complex, probabilistic interactions. FPS-R can provide the deterministic engine needed to explore their emergent behaviors.
+Many biological systems are governed by complex, probabilistic interactions. FPS-R can provide the deterministic engine needed to explore their emergent behaviours.
 - **Protein Folding:** The process by which a protein achieves its functional shape is a high-dimensional search through a vast conformational space. FPS-R can deterministically guide simulations of this process, allowing researchers to replay and analyse the pathways that lead to stable (or misfolded) structures.
 - **Gene Regulatory Networks:** The expression of genes is a noisy, probabilistic process. FPS-R can model the stochastic "on/off" switching of genes, enabling traceable simulations of how cellular states emerge from these complex networks.
 
@@ -537,13 +642,13 @@ Modeling chaotic systems like atmospheric turbulence or ocean currents suffers f
 - **Climate Feedback Loops:** Long-term climate models involve numerous feedback loops with probabilistic elements. Using FPS-R to drive these elements would allow climatologists to run perfectly repeatable, multi-century simulations to analyze the sensitivity of the climate to various factors.
 
 ## 👥 Sociology & Agent-Based Economic Modelling
-Human behavior, especially in large groups, is a classic emergent system based on individual, probabilistic decisions. Multiple instances of FPS-R can drive individual agents, and keep the system deterministic, and study the emerging behaviour of the group.
+Human behaviour, especially in large groups, is a classic emergent system based on individual, probabilistic decisions. Multiple instances of FPS-R can drive individual agents, and keep the system deterministic, and study the emerging behaviour of the group.
 - **Crowd Dynamics:** Simulate the movement of crowds where each individual's decision to turn left or right is guided by a deterministic FPS-R roll. This allows for the study of how stampedes or stable flows emerge from simple rules, with full traceability.
 - **Market Panics & Information Cascades:** Unlike earlier mention of FPS-R in Financial Systems to test adaptability and recoverability in different financial scenarios, this explores the human aspect in various high stress situations, eg, in a financial context.  FPS-R can help simulate reactions and actions that results in, or in reaction to financial conditions. Model financial markets (the environment) where traders' decisions to buy or sell have a probabilistic component. FPS-R allows for the replay of a "flash crash" to understand the precise sequence of trades and information cascades that triggered it. 
 
 ---
 ## 🧶 Final Note: On Language, Timing, and Unfolding
-In the end, FPS-R is not just a tool for generating behavior—it is a grammar of time. It doesn’t simulate noise. It phrases emergence. And the more fluently we learn to read its parameters, the more expressive and explainable our systems become.
+In the end, FPS-R is not just a tool for generating behaviour—it is a grammar of time. It doesn’t simulate noise. It phrases emergence. And the more fluently we learn to read its parameters, the more expressive and explainable our systems become.
 
 Whether shaping synthetic motion, decoding emotional rhythm, or reconstructing plausible memory, FPS-R offers not the right answers, but the right space in which to ask better questions.
 
@@ -552,15 +657,15 @@ Phrasing isn’t about control. It’s about timing. And through timing, we see 
 ---
 # 🔚 Epilogue: From Phrasing to Possibility
 
-FPS-R began as a modulation engine. It has become a **language of behavioral emergence**.
+FPS-R began as a modulation engine. It has become a **language of behavioural emergence**.
 
 At its core, FPS-R offers a new vocabulary for a long-neglected modality: the expressive logic of *random-move-and-hold*. Where most systems focus on decisions, FPS-R focuses on **how decisions unfold**—through rhythm, drift, hesitation, and momentum.
 
 In its most expanded form—with rich capsule libraries, intuitive tools, and a growing community—FPS-R unlocks two powerful paradigms:
 
-- **Generative Expression**: *Latent token drift* enables procedural systems to evolve identity over time, crafting behaviors that breathe, hesitate, and resolve with nuance.
+- **Generative Expression**: *Latent token drift* enables procedural systems to evolve identity over time, crafting behaviours that breathe, hesitate, and resolve with nuance.
   
-- **Behavioral Inference**: *Temporal anchoring* allows analysts and agents to fit observed phenomena to structured phrasing, enabling plausible reconstruction of past events and resonant extrapolation into the future.
+- **behavioural Inference**: *Temporal anchoring* allows analysts and agents to fit observed phenomena to structured phrasing, enabling plausible reconstruction of past events and resonant extrapolation into the future.
 
 These aren’t features—they’re foundations. FPS-R supplies:
 - 🧩 A **notation system** to describe phrased modulation with clarity  


### PR DESCRIPTION
Replaces instances of 'behavioral' with 'behavioural' throughout FPSR_Applications.md for consistency with British English spelling. Also adds a new section on simulation testing and digital twins, detailing FPS-R's role in temporal expressiveness and edge-case discovery in simulation environments.