### PR TITLE
Add clarification on stateful logic scaffolding for `rand()` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Currently, there are limited methods to emulate this realistic and complex behav
 
 ### `rand()`-based Methods
 **Stateful Logic Scaffolding: Holding `rand()` Across Frames**
+
 As mentioned, `rand()` tends to jump values from one seed to the next. It cannot achieve a continuous output even when the input seeds are continuous.
 
 A common workaround to make `rand()` hold its value across frames is to use a stateful logic scaffolding. This involves maintaining a counter variable that tracks how many frames have passed since the last random value was generated. The process typically looks like this:


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Add blank line for better formatting in README


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Improve formatting with blank line addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added blank line after "Stateful Logic Scaffolding" heading for <br>improved readability</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/fpsr/pull/103/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

