### PR TITLE
Update wrapper version availability note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ The wrapper version also has a huge feature: a frame multiplier. A lot of work a
 
 These enhancements make for very meaningful analysis, transparency, traceability and audit workflows.
 
-**(Wrapper version with rich output is currently only available in the C version.)**
+(**Wrapper version with rich output is currently Work in progress**.)
 
 > **[fpsr_tech.md](resources/readme/FPSR_Tech.md)**
   Read more about the technical detail of each algorithm here.


### PR DESCRIPTION
### **User description**
Clarifies that the wrapper version with rich output is currently a work in progress, instead of only being available in the C version.


___

### **PR Type**
Documentation


___

### **Description**
- Update wrapper version availability note in README

- Clarify rich output feature is work in progress


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update wrapper version availability status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated note about wrapper version with rich output availability<br> <li> Changed from "only available in C version" to "Work in progress"</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/fpsr/pull/125/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

