### PR TITLE
Update README with Chinese version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ While every update strives to be more accurate, there will be parts that are inc
 
 # 🎲 FPS-R: Frame-Persistent Stateless Randomisation
 
-[Chinese|中文版 README](./README-CH.md)
+中文版 | [Chinese README](./README-CH.md)
 
 ---
 ## An Audio Introduction: Podcast-Style
@@ -448,5 +448,8 @@ A philosophical exploration of surprise, examining nature's complexity and non-l
 **[Origins, Journals and Reflections](./resources/readme/FPSR_Origins_Journal_Reflections.md)** 
 A record of my development journey, including inspirations and challenges encountered along the way.
 
-**[fpsr_algoAnalysis.ipynb](./resources/code/data_analysis/fpsr_algoAnalysis.ipynb)** 
+**[fpsr_algoAnalysis](./resources/code/data_analysis/fpsr_algoAnalysis.ipynb)** 
 A Jupyter notebook with data graph plots for interactive exploration and experimentation. Try it out yourself!
+
+**[README-CH](./README-CH.md)** 
+The Chinese version of this document.


### PR DESCRIPTION
### **User description**
Improved the link to the Chinese README and added a dedicated section referencing the Chinese version of the document for better accessibility.


___

### **PR Type**
Documentation


___

### **Description**
- Improved Chinese README link formatting and visibility

- Added dedicated Chinese version reference section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Chinese link"] --> B["Reformatted link display"]
  B --> C["Added dedicated reference section"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Enhanced Chinese README accessibility and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Reformatted Chinese README link from bracketed format to cleaner <br>display<br> <li> Added new reference section for Chinese version at document end<br> <li> Minor formatting fix removing <code>.ipynb</code> extension from link text</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/fpsr/pull/129/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

