### PR TITLE
Add reverse playback controls to FPSR demo

### DIFF
--- a/resources/code/html_javascript/fpsr_demo.html
+++ b/resources/code/html_javascript/fpsr_demo.html
@@ -292,6 +292,14 @@
                     <span>Rewind</span>
                 </button>
                 
+                                <button id="reverseButton" class="w-full md:w-auto bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2">
+                                    <!-- Pause Icon (Rev) -->
+                                    <svg id="pauseIconRev" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="display: none;"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
+                                    <!-- Play Reverse Icon -->
+                                    <svg id="playIconRev" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.445-10.832a1 1 0 00-1.555-.832l-3 2a1 1 0 000 1.664l3 2a1 1 0 001.555-.832V8z" clip-rule="evenodd"></path></svg>
+                                    <span id="reverseButtonText">Reverse</span>
+                                </button>
+
                                 <button id="pauseButton" class="w-full md:w-auto bg-yellow-600 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2">
                                     <!-- Pause Icon -->
                                     <svg id="pauseIcon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
@@ -322,7 +330,7 @@
             let frame = 0; // This is the "Application Timeline" frame
             let history = [];
             let activeAlgorithm = 'SM';
-            let isPaused = false;
+            let playDirection = 1; // 1 = forward, -1 = reverse, 0 = paused
             let animationFrameId = null;
 
             // --- Global parameters object ---
@@ -344,6 +352,10 @@
             const pauseButtonText = document.getElementById('pauseButtonText');
             const pauseIcon = document.getElementById('pauseIcon');
             const playIcon = document.getElementById('playIcon');
+            const reverseButton = document.getElementById('reverseButton');
+            const reverseButtonText = document.getElementById('reverseButtonText');
+            const pauseIconRev = document.getElementById('pauseIconRev');
+            const playIconRev = document.getElementById('playIconRev');
             const rewindButton = document.getElementById('rewindButton');
             const copyButton = document.getElementById('copyButton');
             
@@ -525,22 +537,52 @@
             });
 
             // --- Button Listeners ---
-            function togglePause() {
-                isPaused = !isPaused;
-                if (isPaused) {
-                    pauseButtonText.textContent = 'Play';
-                    pauseIcon.style.display = 'none';
-                    playIcon.style.display = 'block';
-                    if (animationFrameId) {
-                        cancelAnimationFrame(animationFrameId);
-                        animationFrameId = null;
-                    }
-                } else {
+            function updatePlaybackUI() {
+                if (playDirection === 1) {
                     pauseButtonText.textContent = 'Pause';
                     pauseIcon.style.display = 'block';
                     playIcon.style.display = 'none';
-                    animate();
+
+                    reverseButtonText.textContent = 'Reverse';
+                    pauseIconRev.style.display = 'none';
+                    playIconRev.style.display = 'block';
+                } else if (playDirection === -1) {
+                    pauseButtonText.textContent = 'Forward';
+                    pauseIcon.style.display = 'none';
+                    playIcon.style.display = 'block';
+
+                    reverseButtonText.textContent = 'Pause';
+                    pauseIconRev.style.display = 'block';
+                    playIconRev.style.display = 'none';
+                } else {
+                    pauseButtonText.textContent = 'Forward';
+                    pauseIcon.style.display = 'none';
+                    playIcon.style.display = 'block';
+
+                    reverseButtonText.textContent = 'Reverse';
+                    pauseIconRev.style.display = 'none';
+                    playIconRev.style.display = 'block';
                 }
+            }
+
+            function toggleForward() {
+                if (playDirection === 1) {
+                    playDirection = 0; // Pause
+                } else {
+                    playDirection = 1; // Play Forward
+                    if (!animationFrameId) animate();
+                }
+                updatePlaybackUI();
+            }
+
+            function toggleReverse() {
+                if (playDirection === -1) {
+                    playDirection = 0; // Pause
+                } else {
+                    playDirection = -1; // Play Reverse
+                    if (!animationFrameId) animate();
+                }
+                updatePlaybackUI();
             }
 
             function rewindAnimation() {
@@ -549,7 +591,8 @@
                 ctx.clearRect(0, 0, canvasWidth, canvasHeight);
             }
 
-            pauseButton.addEventListener('click', togglePause);
+            pauseButton.addEventListener('click', toggleForward);
+            reverseButton.addEventListener('click', toggleReverse);
             rewindButton.addEventListener('click', rewindAnimation);
 
             // --- Copy buffer to clipboard ---
@@ -936,7 +979,7 @@
 
             // --- Animation Loop ---
             function animate() {
-                if (isPaused) {
+                if (playDirection === 0) {
                     if (animationFrameId) {
                         cancelAnimationFrame(animationFrameId);
                         animationFrameId = null;
@@ -951,12 +994,25 @@
                     frame = 0;
                 }
 
-                // *** MODIFIED: Call the new HPQ wrapper function ***
-                const newValue = getFpsrValue(frame);
-                history.push(newValue);
+                if (playDirection === 1) {
+                    const newValue = getFpsrValue(frame);
+                    history.push(newValue);
 
-                if (history.length > canvasWidth) {
-                    history.shift();
+                    if (history.length > canvasWidth) {
+                        history.shift();
+                    }
+                    frame++; 
+                } else if (playDirection === -1) {
+                    // Frame represents the rightmost edge + 1. Find the new leftmost missing frame.
+                    const newValue = getFpsrValue(frame - history.length - 1);
+                    history.unshift(newValue);
+                    
+                    if (history.length > canvasWidth) {
+                        // Only truncate the rightmost end if the buffer has exceeded the canvas width
+                        history.pop();
+                        // Only step the right edge backwards if we actually removed a frame from the right
+                        frame--;
+                    }
                 }
 
                 ctx.clearRect(0, 0, canvasWidth, canvasHeight);
@@ -982,7 +1038,7 @@
                     }
                 }
                 ctx.stroke();
-                frame++; // Increment the "Application Timeline" frame
+                
                 animationFrameId = requestAnimationFrame(animate);
             }
 


### PR DESCRIPTION
Introduces a new Reverse button with dedicated play/pause icons and labels, and replaces the old boolean pause state with a `playDirection` mode (forward, reverse, paused). The animation loop now supports stepping backward by prepending prior frame values while keeping the history buffer bounded, and updates both control buttons to reflect current playback direction.