### PR TITLE
Feature/update code lod

### DIFF
--- a/resources/code/data_analysis/fpsr_algoAnalysis.ipynb
+++ b/resources/code/data_analysis/fpsr_algoAnalysis.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 150,
    "id": "191b4f6f",
    "metadata": {
     "executionInfo": {
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 151,
    "id": "e8023108",
    "metadata": {
     "executionInfo": {
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 152,
    "id": "f47909e9",
    "metadata": {},
    "outputs": [
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 153,
    "id": "91d65af8",
    "metadata": {},
    "outputs": [],
@@ -340,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 154,
    "id": "431e22ac",
    "metadata": {
     "executionInfo": {
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 155,
    "id": "b5fbb99d",
    "metadata": {
     "executionInfo": {
@@ -497,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 156,
    "id": "cac3828b",
    "metadata": {
     "executionInfo": {
@@ -626,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 157,
    "id": "e0039491",
    "metadata": {},
    "outputs": [],
@@ -783,7 +783,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 158,
    "id": "2ca40781",
    "metadata": {},
    "outputs": [],
@@ -962,7 +962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 159,
    "id": "97d19635",
    "metadata": {},
    "outputs": [],
@@ -1125,7 +1125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 160,
    "id": "7c2dc3ec",
    "metadata": {},
    "outputs": [],
@@ -1296,7 +1296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 161,
    "id": "0b1c4ec5",
    "metadata": {},
    "outputs": [],
@@ -1467,7 +1467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 162,
    "id": "BETOeYRQk7rO",
    "metadata": {
     "executionInfo": {
@@ -1525,7 +1525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 163,
    "id": "x9DErnrZlT_P",
    "metadata": {
     "executionInfo": {
@@ -1584,7 +1584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 164,
    "id": "ehdB1rA5jZEc",
    "metadata": {
     "executionInfo": {
@@ -1646,7 +1646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 165,
    "id": "6a874388",
    "metadata": {},
    "outputs": [],
@@ -1702,7 +1702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 166,
    "id": "b1d4c3e5",
    "metadata": {
     "executionInfo": {
@@ -1749,7 +1749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 167,
    "id": "f55af73f",
    "metadata": {},
    "outputs": [],
@@ -1786,7 +1786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 168,
    "id": "a30b125d",
    "metadata": {},
    "outputs": [
@@ -1806,7 +1806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 169,
    "id": "7a_rA4yxnz1D",
    "metadata": {
     "colab": {
@@ -1856,7 +1856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 170,
    "id": "2d8cd05a",
    "metadata": {},
    "outputs": [],
@@ -1893,7 +1893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 171,
    "id": "58f1cbdd",
    "metadata": {},
    "outputs": [
@@ -1916,6 +1916,13 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of jumps in random.random(): 400 out of 400 steps. Jump frequency: 100.00%\n"
+     ]
     }
    ],
    "source": [
@@ -1928,7 +1935,10 @@
     "# output the changed steps list\n",
     "held_steps = held_steps_list(values_changed)\n",
     "# print(held_steps)\n",
-    "held_step_values(held_steps, [1]*len(held_steps), seq_name='random.random()')"
+    "held_step_values(held_steps, [1]*len(held_steps), seq_name='random.random()')\n",
+    "\n",
+    "# print the number of jumps\n",
+    "print(f\"Number of jumps in random.random(): {sum(values_changed)} out of {len(values_changed)} steps. Jump frequency: {sum(values_changed)/len(values_changed)*100:.2f}%\")"
    ]
   },
   {
@@ -1949,7 +1959,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 172,
    "id": "f9a83625",
    "metadata": {},
    "outputs": [
@@ -1972,6 +1982,13 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of jumps in Portable-Rand: 400 out of 400 steps. Jump frequency: 100.00%\n"
+     ]
     }
    ],
    "source": [
@@ -1982,7 +1999,10 @@
     "# output the changed steps list\n",
     "held_steps = held_steps_list(values_changed)\n",
     "# print(held_steps)\n",
-    "held_step_values(held_steps, [1]*len(held_steps), seq_name='Portable-Rand')"
+    "held_step_values(held_steps, [1]*len(held_steps), seq_name='Portable-Rand')\n",
+    "\n",
+    "# print the number of jumps\n",
+    "print(f\"Number of jumps in Portable-Rand: {sum(values_changed)} out of {len(values_changed)} steps. Jump frequency: {sum(values_changed)/len(values_changed)*100:.2f}%\")"
    ]
   },
   {
@@ -2006,7 +2026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 173,
    "id": "ZYvrUCoul2hD",
    "metadata": {
     "colab": {
@@ -2055,7 +2075,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 174,
    "id": "3354e7a4",
    "metadata": {},
    "outputs": [
@@ -2068,13 +2088,22 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of jumps in FPS-R SM: 21 out of 400 steps. Jump frequency: 5.25%\n"
+     ]
     }
    ],
    "source": [
     "# output the changed steps list\n",
     "held_steps = held_steps_list(values_changed)\n",
     "# print(held_steps)\n",
-    "held_step_values(held_steps, [1]*len(held_steps), seq_name='FPS-R SM')"
+    "held_step_values(held_steps, [1]*len(held_steps), seq_name='FPS-R SM')\n",
+    "# print the number of jumps\n",
+    "print(f\"Number of jumps in FPS-R SM: {sum(values_changed)} out of {len(values_changed)} steps. Jump frequency: {sum(values_changed)/len(values_changed)*100:.2f}%\")"
    ]
   },
   {
@@ -2089,7 +2118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 175,
    "id": "-fp0gtLKmG6A",
    "metadata": {
     "colab": {
@@ -2174,7 +2203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 176,
    "id": "ab5224b2",
    "metadata": {
     "colab": {
@@ -2223,7 +2252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 177,
    "id": "84d25ddd",
    "metadata": {},
    "outputs": [
@@ -2236,18 +2265,27 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of jumps in FPS-R TM: 50 out of 400 steps. Jump frequency: 12.50%\n"
+     ]
     }
    ],
    "source": [
     "# output the changed steps list\n",
     "held_steps = held_steps_list(values_changed)\n",
     "# print(held_steps)\n",
-    "held_step_values(held_steps, [1]*len(held_steps), seq_name='FPS-R TM')"
+    "held_step_values(held_steps, [1]*len(held_steps), seq_name='FPS-R TM')\n",
+    "# print the number of jumps\n",
+    "print(f\"Number of jumps in FPS-R TM: {sum(values_changed)} out of {len(values_changed)} steps. Jump frequency: {sum(values_changed)/len(values_changed):.2%}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 178,
    "id": "fe8d09ba",
    "metadata": {
     "colab": {
@@ -2332,7 +2370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 179,
    "id": "41b594e2",
    "metadata": {
     "colab": {
@@ -2381,7 +2419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 180,
    "id": "4496508f",
    "metadata": {},
    "outputs": [
@@ -2394,18 +2432,27 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of jumps in FPS-R QS: 85 out of 400 steps. Jump frequency: 21.25%\n"
+     ]
     }
    ],
    "source": [
     "# output the changed steps list\n",
     "held_steps = held_steps_list(values_changed)\n",
     "# print(held_steps)\n",
-    "plot_values(held_steps, [1]*len(held_steps), seq_name='FPS-R QS Held Steps')"
+    "plot_values(held_steps, [1]*len(held_steps), seq_name='FPS-R QS Held Steps')\n",
+    "# print the number of jumps\n",
+    "print(f\"Number of jumps in FPS-R QS: {len(held_steps)} out of {len(values_changed)} steps. Jump frequency: {len(held_steps)/len(values_changed):.2%}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 181,
    "id": "9d779c01",
    "metadata": {
     "colab": {
@@ -2488,7 +2535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 182,
    "id": "4515f1dd",
    "metadata": {},
    "outputs": [
@@ -2520,7 +2567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 183,
    "id": "ed95ffc5",
    "metadata": {},
    "outputs": [
@@ -2533,13 +2580,22 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of jumps in FPS-R BD: 116 out of 400 steps. Jump frequency: 29.00%\n"
+     ]
     }
    ],
    "source": [
     "# output the changed steps list\n",
     "held_steps = held_steps_list(values_changed)\n",
     "# print(held_steps)\n",
-    "held_step_values(held_steps, [1]*len(held_steps), seq_name='FPS-R BD')"
+    "held_step_values(held_steps, [1]*len(held_steps), seq_name='FPS-R BD')\n",
+    "# print the number of jumps\n",
+    "print(f\"Number of jumps in FPS-R BD: {len(held_steps)} out of {len(values_changed)} steps. Jump frequency: {len(held_steps)/len(values_changed):.2%}\")"
    ]
   },
   {
@@ -2552,7 +2608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 184,
    "id": "fd974444",
    "metadata": {},
    "outputs": [
@@ -2620,7 +2676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 185,
    "id": "50df6bb3",
    "metadata": {},
    "outputs": [

--- a/resources/code/html_javascript/fpsr_demo.html
+++ b/resources/code/html_javascript/fpsr_demo.html
@@ -71,6 +71,66 @@
         <!-- Canvas for visualization -->
         <canvas id="visualizerCanvas" class="w-full mb-6 shadow-lg" height="300"></canvas>
 
+        <!-- Transport Bar & Speed Controls Bar -->
+        <div class="flex flex-col gap-4 mb-6">
+            <!-- Transport Buttons Bar -->
+            <div class="flex flex-col md:flex-row gap-4 bg-gray-800 p-4 rounded-lg shadow-lg">
+                <button id="resetButton" class="w-full md:w-auto bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md transition duration-150" title="Resets the visualizer to the beginning of the timeline and generates new random seeds for the algorithms.">
+                    Reset (New Seeds)
+                </button>
+                <button id="rewindButton" class="w-full md:w-auto bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2" title="Rewinds the visualizer to the beginning of the timeline.">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.066 11.209a1.001 1.001 0 00-1.414 0l-3 3a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414-1.414L9.414 16H18a1 1 0 100-2h-8.586l1.652-1.652a1 1 0 000-1.414zM18 18v-2"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 12V6a1 1 0 011-1h10a1 1 0 011 1v6"></path></svg>
+                    <span>Rewind</span>
+                </button>
+                
+                <button id="reverseButton" class="w-full md:w-auto bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2" title="Play/Pause the visualizer in the reverse direction.">
+                    <!-- Pause Icon (Rev) -->
+                    <svg id="pauseIconRev" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="display: none;"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
+                    <!-- Play Reverse Icon -->
+                    <svg id="playIconRev" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.445-10.832a1 1 0 00-1.555-.832l-3 2a1 1 0 000 1.664l3 2a1 1 0 001.555-.832V8z" clip-rule="evenodd"></path></svg>
+                    <span id="reverseButtonText">Reverse</span>
+                </button>
+
+                <button id="pauseButton" class="w-full md:w-auto bg-yellow-600 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2" title="Play/Pause the visualizer in the forward direction.">
+                    <!-- Pause Icon -->
+                    <svg id="pauseIcon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
+                    <!-- Play Icon -->
+                    <svg id="playIcon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="display: none;"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"></path></svg>
+                    <span id="pauseButtonText">Pause</span>
+                </button>
+
+                <!-- Copy values to Clipboard -->
+                <button id="copyButton" class="w-full md:w-auto bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 ml-auto" title="Copies current values to the clipboard, in a python formatted list, (eg [0.022, 0.378, 0.795...]).&#10;This enables offline data analysis of FPS-R outputs.">
+                    Copy Values to Clipboard
+                </button>
+            </div>
+
+            <!-- Scroll Speed Controls & Performance Monitor -->
+            <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4 bg-gray-800 p-4 rounded-lg shadow-lg">
+                <div class="flex flex-wrap items-center gap-3">
+                    <label for="scrollSpeed" class="text-xs font-semibold text-gray-300 uppercase">Scroll Speed:</label>
+                    <input id="scrollSpeed" type="range" min="0.1" max="10" value="1.0" step="0.1" class="w-32 md:w-48">
+                    <span id="scrollSpeedValue" class="text-sm text-white font-mono w-14 text-right">1.0x</span>
+                    <button id="resetScrollSpeedButton" class="bg-gray-600 hover:bg-gray-700 text-white font-bold py-1 px-2 rounded-md text-xs transition duration-150" title="Reset speed to 1.0x">
+                        1.0x
+                    </button>
+                    <div class="flex items-center space-x-1 pl-2 border-l border-gray-600" title="Set the maximum limit for the speed slider">
+                        <label for="scrollSpeedMaxInput" class="text-xs text-gray-400">Max Limit:</label>
+                        <input id="scrollSpeedMaxInput" type="number" value="10" min="1" step="1" class="w-16 bg-gray-700 text-white border-gray-600 rounded-md p-1 text-xs text-center">
+                    </div>
+                    <div class="flex items-center space-x-1.5 pl-2 border-l border-gray-600" title="Unconstrained processing mode - generates data as fast as CPU allows">
+                        <input id="scrollSpeedMaxToggle" type="checkbox" class="w-4 h-4 bg-gray-700 text-blue-500 border-gray-600 rounded-md">
+                        <label for="scrollSpeedMaxToggle" class="text-xs font-bold text-yellow-400 cursor-pointer">MAX</label>
+                    </div>
+                </div>
+
+                <div class="flex items-center space-x-2 bg-gray-900 px-3 py-1.5 rounded border border-gray-700" title="FPS-R algorithm evaluations computed per second (3s rolling average)">
+                    <span class="text-xs text-gray-400 uppercase tracking-wide font-semibold">FPS-R Evals/Sec:</span>
+                    <span id="evalRateDisplay" class="text-sm font-mono font-bold text-green-400">0</span>
+                </div>
+            </div>
+        </div>
+
         <!-- Algorithm Tabs -->
         <div class="flex space-x-1 rounded-t-lg overflow-hidden">
             <button id="tab-SM" data-algo="SM" class="tab active flex-1 py-3 px-4 font-semibold transition-colors duration-150">FPS-R: SM</button>
@@ -281,40 +341,6 @@
                 </div>
             </div>
 
-
-            <!-- Shared Controls -->
-            <div class="flex flex-col md:flex-row gap-4 mt-6 pt-6 border-t border-gray-700">
-                <button id="resetButton" class="w-full md:w-auto bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md transition duration-150" title="Resets the visualizer to the beginning of the timeline and generates new random seeds for the algorithms.">
-                    Reset (New Seeds)
-                </button>
-                <button id="rewindButton" class="w-full md:w-auto bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2" title="Rewinds the visualizer to the beginning of the timeline.">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.066 11.209a1.001 1.001 0 00-1.414 0l-3 3a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414-1.414L9.414 16H18a1 1 0 100-2h-8.586l1.652-1.652a1 1 0 000-1.414zM18 18v-2"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 12V6a1 1 0 011-1h10a1 1 0 011 1v6"></path></svg>
-                    <span>Rewind</span>
-                </button>
-                
-                                <button id="reverseButton" class="w-full md:w-auto bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2" title="Play/Pause the visualizer in the reverse direction.">
-                                    <!-- Pause Icon (Rev) -->
-                                    <svg id="pauseIconRev" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="display: none;"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
-                                    <!-- Play Reverse Icon -->
-                                    <svg id="playIconRev" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.445-10.832a1 1 0 00-1.555-.832l-3 2a1 1 0 000 1.664l3 2a1 1 0 001.555-.832V8z" clip-rule="evenodd"></path></svg>
-                                    <span id="reverseButtonText">Reverse</span>
-                                </button>
-
-                                <button id="pauseButton" class="w-full md:w-auto bg-yellow-600 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded-md transition duration-150 flex items-center justify-center space-x-2" title="Play/Pause the visualizer in the forward direction.">
-                                    <!-- Pause Icon -->
-                                    <svg id="pauseIcon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
-                                    <!-- Play Icon -->
-                                    <svg id="playIcon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="display: none;"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"></path></svg>
-                                    <span id="pauseButtonText">Pause</span>
-                                </button>
-
-                <!-- NEW: Copy values to Clipboard -->
-                <button id="copyButton" class="w-full md:w-auto bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md transition duration-150" title="Copies current values to the clipboard, in a python formatted list, (eg [0.022, 0.378, 0.795...]).&#10;This enables offline data analysis of FPS-R outputs.">
-                    Copy Values to Clipboard
-                </button>
-            </div>
-        </div>
-
     </div>
 
     <script>
@@ -332,6 +358,11 @@
             let activeAlgorithm = 'SM';
             let playDirection = 1; // 1 = forward, -1 = reverse, 0 = paused
             let animationFrameId = null;
+
+            // --- Scroll Speed & Performance State ---
+            let stepAccumulator = 0;
+            let evalsLog = []; // [{ time: ms, count: N }] for 3-second rolling average
+            let appStartTime = performance.now();
 
             // --- Global parameters object ---
             let globalParams = {
@@ -363,6 +394,46 @@
             const frameMultiplierSlider = document.getElementById('global_frameMultiplier');
             const frameMultiplierValue = document.getElementById('global_frameMultiplierValue');
             const resetFrameMultiplierButton = document.getElementById('resetFrameMultiplierButton'); // NEW
+
+            // --- Scroll Speed UI Elements ---
+            const scrollSpeedSlider = document.getElementById('scrollSpeed');
+            const scrollSpeedValue = document.getElementById('scrollSpeedValue');
+            const resetScrollSpeedButton = document.getElementById('resetScrollSpeedButton');
+            const scrollSpeedMaxInput = document.getElementById('scrollSpeedMaxInput');
+            const scrollSpeedMaxToggle = document.getElementById('scrollSpeedMaxToggle');
+            const evalRateDisplay = document.getElementById('evalRateDisplay');
+
+            // Speed slider UI handlers
+            scrollSpeedSlider.addEventListener('input', (e) => {
+                scrollSpeedValue.textContent = parseFloat(e.target.value).toFixed(1) + 'x';
+            });
+
+            resetScrollSpeedButton.addEventListener('click', () => {
+                scrollSpeedSlider.value = "1.0";
+                scrollSpeedValue.textContent = "1.0x";
+            });
+
+            scrollSpeedMaxInput.addEventListener('change', (e) => {
+                let maxVal = parseFloat(e.target.value);
+                if (isNaN(maxVal) || maxVal < 1) maxVal = 1;
+                scrollSpeedMaxInput.value = maxVal;
+                scrollSpeedSlider.max = maxVal;
+                if (parseFloat(scrollSpeedSlider.value) > maxVal) {
+                    scrollSpeedSlider.value = maxVal;
+                    scrollSpeedValue.textContent = maxVal.toFixed(1) + 'x';
+                }
+            });
+
+            scrollSpeedMaxToggle.addEventListener('change', (e) => {
+                const disabled = e.target.checked;
+                scrollSpeedSlider.disabled = disabled;
+                resetScrollSpeedButton.disabled = disabled;
+                scrollSpeedMaxInput.disabled = disabled;
+                
+                scrollSpeedSlider.style.opacity = disabled ? '0.4' : '1.0';
+                resetScrollSpeedButton.style.opacity = disabled ? '0.4' : '1.0';
+                scrollSpeedMaxInput.style.opacity = disabled ? '0.4' : '1.0';
+            });
 
             // --- Helper for range sliders ---
             document.querySelectorAll('input[type="range"]').forEach(slider => {
@@ -977,9 +1048,19 @@
             }
 
 
-            // --- Animation Loop ---
             function animate() {
+                const now = performance.now();
+
                 if (playDirection === 0) {
+                    // Update rolling 3-second evaluations rate even when paused
+                    evalsLog.push({ time: now, count: 0 });
+                    while (evalsLog.length > 0 && evalsLog[0].time < now - 3000) {
+                        evalsLog.shift();
+                    }
+                    let totalEvalsPaused = evalsLog.reduce((sum, item) => sum + item.count, 0);
+                    let spanPaused = Math.min(3.0, (now - appStartTime) / 1000);
+                    evalRateDisplay.textContent = (spanPaused > 0 ? Math.round(totalEvalsPaused / spanPaused) : 0).toLocaleString();
+
                     if (animationFrameId) {
                         cancelAnimationFrame(animationFrameId);
                         animationFrameId = null;
@@ -994,26 +1075,46 @@
                     frame = 0;
                 }
 
-                if (playDirection === 1) {
-                    const newValue = getFpsrValue(frame);
-                    history.push(newValue);
+                // Determine step count based on speed / max mode
+                let stepsToCompute = 0;
+                if (scrollSpeedMaxToggle.checked) {
+                    stepsToCompute = 5000; // Fast unconstrained batch computation per render tick
+                } else {
+                    const currentSpeed = parseFloat(scrollSpeedSlider.value);
+                    stepAccumulator += currentSpeed;
+                    stepsToCompute = Math.floor(stepAccumulator);
+                    stepAccumulator -= stepsToCompute;
+                }
 
-                    if (history.length > canvasWidth) {
-                        history.shift();
-                    }
-                    frame++; 
-                } else if (playDirection === -1) {
-                    // Frame represents the rightmost edge + 1. Find the new leftmost missing frame.
-                    const newValue = getFpsrValue(frame - history.length - 1);
-                    history.unshift(newValue);
-                    
-                    if (history.length > canvasWidth) {
-                        // Only truncate the rightmost end if the buffer has exceeded the canvas width
-                        history.pop();
-                        // Only step the right edge backwards if we actually removed a frame from the right
-                        frame--;
+                for (let s = 0; s < stepsToCompute; s++) {
+                    if (playDirection === 1) {
+                        const newValue = getFpsrValue(frame);
+                        history.push(newValue);
+
+                        if (history.length > canvasWidth) {
+                            history.shift();
+                        }
+                        frame++; 
+                    } else if (playDirection === -1) {
+                        const newValue = getFpsrValue(frame - history.length - 1);
+                        history.unshift(newValue);
+                        
+                        if (history.length > canvasWidth) {
+                            history.pop();
+                            frame--;
+                        }
                     }
                 }
+
+                // --- 3-second Rolling Evaluations Average ---
+                evalsLog.push({ time: now, count: stepsToCompute });
+                while (evalsLog.length > 0 && evalsLog[0].time < now - 3000) {
+                    evalsLog.shift();
+                }
+                let totalEvals = evalsLog.reduce((sum, item) => sum + item.count, 0);
+                let windowSpan = Math.min(3.0, (now - appStartTime) / 1000);
+                let evalsPerSec = windowSpan > 0 ? Math.round(totalEvals / windowSpan) : 0;
+                evalRateDisplay.textContent = evalsPerSec.toLocaleString();
 
                 ctx.clearRect(0, 0, canvasWidth, canvasHeight);
                 ctx.beginPath();


### PR DESCRIPTION
Add jump frequency summaries to analysis notebook
Updated the FPSR analysis notebook to print per-sequence jump counts and jump frequency percentages after held-step calculations (e.g., random.random(), Portable-Rand, and FPS-R variants). This makes the notebook output easier to compare across generators without relying only on plots.

Add transport speed controls to FPSR demo
Reworks the FPS-R demo controls by moving the transport bar up under the canvas and adding a dedicated speed/performance panel. The animation loop now supports adjustable playback speed, an unconstrained max mode, and a rolling evaluations-per-second display so users can both navigate and benchmark the demo more effectively.