### PR TITLE
Document visualizer benchmark environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## [3.0.2] - 2026-08-07
+### Changed
+- Algorithm Analysis Jupyter Notebook (`resources\code\data_analysis\fpsr_algoAnalysis.ipynb`)
+    - Updated the FPSR analysis notebook to print per-sequence jump counts and jump frequency percentages after held-step calculations (e.g., `random.random()`, `Portable-Rand`, and FPS-R variants). This makes the notebook output easier to compare across generators without relying only on plots.
+- Visualizer (`resources/code/html_javascript/fpsr_demo.html`)
+    - Reworked the FPS-R demo controls by moving the transport bar up under the canvas and adding a dedicated speed/performance panel. The animation loop now supports adjustable playback speed, an unconstrained max mode, and a rolling evaluations-per-second display so users can both navigate and benchmark the demo more effectively.
+    - Added a 'Legacy Stateful (Comparison)' tab to the FPSR demo that implements the classic hold-and-jump stateful accumulator loop. Includes UI panel with minHoldFrames and jumpProbability controls, disables reverse playback and HPQ time controls when active (since stateful memory cannot step backward), and resets legacy state variables on param changes.
+    - Updated the demo playback loop so MAX speed mode now runs with a time-budgeted compute window per frame (instead of a fixed step count), improving uncapped playback responsiveness while keeping standard slider-based stepping behavior unchanged.
+- FPS-R Visualiser Performance Metrics(`resources\code\html_javascript\benchmmarks\fpsr_visualiser_metrics.md`)
+    - Documented observed FPS-R visualizer throughput metrics in a new benchmark markdown file, including Bitwise Decode stream/blocksize breakdowns. 
 
 ## [3.0.1] - 2025-01-14
 

--- a/resources/code/html_javascript/benchmmarks/fpsr_visualiser_metrics.md
+++ b/resources/code/html_javascript/benchmmarks/fpsr_visualiser_metrics.md
@@ -1,16 +1,37 @@
 
 # FPS-R Visualiser Performance Metrics
 
-### 
 Using the FPS-R Visualizer default settings for each algorithm, the following approximate performance metrics were observed.
 
-## HTML Preview in Visual Studio Code
+---
+## PC Specifications
+| Specification | Details |
+| :--- | --- |
+| Processor | AMD Ryzen 9 3900X 12-Core, 3.80 GHz |
+| Installed RAM | 64.0 GB |
+| Graphics Card | NVIDIA GeForce RTX 2080 Ti (11 GB) |
+| System Type | 64-bit operating system, x64-based processor |
+| Operating System | Windows 10 Home |
 
+---
+## HTML Preview in Visual Studio Code
+### VS Code Version Information
+| Specification | Details |
+| :--- | --- |
+| Version | 1.99.2 (user setup) |
+| Electron | 34.3.2 |
+| ElectronBuildId | 11161073 |
+| Chromium | 132.0.6834.210 |
+| Node.js | 20.18.3 |
+| V8 | 13.2.152.41-electron.0 |
+| OS | Windows_NT x64 10.0.19045 |
+
+### Algorithm Performance Metrics
 | Algorithm | Approximate Performance |
 | :--- | --- |
-Legacy Stateful `rand()` | ~2, 3xx k/s |
-Stacked Modulo | ~1, 4xx k/s |
-Toggled Modulo | ~1, 74x k/s |
+Legacy Stateful `rand()` | ~2, 300 k/s |
+Stacked Modulo | ~1, 400 k/s |
+Toggled Modulo | ~1, 740 k/s |
 Quantised Switching | ~880 k/s |
 Bitwise Decode (default 7 streams, blocksize 30) |  ~179 k/s |
 
@@ -25,3 +46,91 @@ Bitwise Decode (default 7 streams, blocksize 30) |  ~179 k/s |
 |   | 60 | ~289 k/s |
 | 7 | 30 | ~179 k/s |
 |   | 60 | ~151 k/s |
+
+---
+## Chrome Browser 
+### Chrome Version Information
+Version 151.0.7922.34 (Official Build) (64-bit)
+
+### Algorithm Performance Metrics
+| Algorithm | Approximate Performance |
+| :--- | --- |
+| Legacy Stateful `rand()` | ~2, 800 k/s |
+| Stacked Modulo | ~1, 580 k/s |
+| Toggled Modulo | ~2, 130 k/s |
+| Quantised Switching | ~920 k/s |
+| Bitwise Decode (default 7 streams, blocksize 30) | ~188 k/s |
+
+### BD Breakdown by Streams and Blocksize
+| Streams | Blocksize | Approximate Performance |
+| :--- | --- | --- |
+| 1 | 30 | ~705 k/s |
+|   | 60 | ~700 k/s |
+| 2 | 30 | ~505 k/s |
+|   | 60 | ~504 k/s |
+| 4 | 30 | ~325 k/s |
+|   | 60 | ~324 k/s |
+| 7 | 30 | ~192 k/s |
+|   | 60 | ~179 k/s |
+
+---
+## Firefox Browser
+### Firefox Version Information
+Version 153.0.3 (64-bit)
+
+### Algorithm Performance Metrics
+| Algorithm | Approximate Performance |
+| :--- | --- |
+| Legacy Stateful `rand()` | ~7, 600 k/s |
+| Stacked Modulo | ~1, 060 k/s |
+| Toggled Modulo | ~1, 750 k/s |
+| Quantised Switching | ~660 k/s |
+| Bitwise Decode (default 7 streams, blocksize 30) | ~176 k/s |
+
+### BD Breakdown by Streams and Blocksize
+| Streams | Blocksize | Approximate Performance |
+| :--- | --- | --- |
+| 1 | 30 | ~646 k/s |
+|   | 60 | ~605 k/s |
+| 2 | 30 | ~435 k/s |
+|   | 60 | ~440 k/s |
+| 4 | 30 | ~295 k/s |
+|   | 60 | ~283 k/s |
+| 7 | 30 | ~170 k/s |
+|   | 60 | ~157 k/s |
+
+---
+## Android Phone Specifications
+| Specification | Details |
+| :--- | --- |
+| Samsung | Galaxy S23 Ultra 5G |
+| Model | SM-S918B/DS |
+| Processor | Qualcomm Snapdragon 8 Gen 2 |
+| Memory | 12 GB |
+| System Type | 64-bit operating system, arm64-based processor |
+| Android Version | 16 |
+
+## Android Chrome Browser
+### Chrome Version Information
+Version 151.0.7922.83
+
+### Algorithm Performance Metrics
+| Algorithm | Approximate Performance |
+| :--- | --- |
+| Legacy Stateful `rand()` | ~2, 930 k/s |
+| Stacked Modulo | ~1, 830 k/s |
+| Toggled Modulo | ~2, 280 k/s |
+| Quantised Switching | ~1, 080 k/s |
+| Bitwise Decode (default 7 streams, blocksize 30) | ~268 k/s |
+
+### BD Breakdown by Streams and Blocksize
+| Streams | Blocksize | Approximate Performance |
+| :--- | --- | --- |
+| 1 | 30 | ~830 k/s |
+|   | 60 | ~820 k/s |
+| 2 | 30 | ~680 k/s |
+|   | 60 | ~682 k/s |
+| 4 | 30 | ~375 k/s |
+|   | 60 | ~390 k/s |
+| 7 | 30 | ~210 k/s |
+|   | 60 | ~200 k/s |


### PR DESCRIPTION
Expand the FPS-R visualizer metrics document with hardware specs plus VS Code, desktop browser, and Android benchmark results, including Bitwise Decode stream/blocksize breakdowns. Update the changelog for 3.0.2 to note the new benchmark documentation and related notebook/demo changes.