### PR TITLE
Feature/update code lod

### DIFF
--- a/resources/code/html_javascript/benchmmarks/fpsr_visualiser_metrics.md
+++ b/resources/code/html_javascript/benchmmarks/fpsr_visualiser_metrics.md
@@ -33,7 +33,7 @@ Legacy Stateful `rand()` | ~2, 300 k/s |
 Stacked Modulo | ~1, 400 k/s |
 Toggled Modulo | ~1, 740 k/s |
 Quantised Switching | ~880 k/s |
-Bitwise Decode (default 3 streams, blocksize 60) |  ~333 k/s |
+Bitwise Decode (default 3 streams, blocksize 60) | ~333 k/s |
 
 ### BD Breakdown by Streams and Blocksize
 | Streams | Blocksize | Approximate Performance |

--- a/resources/code/html_javascript/fpsr_demo.html
+++ b/resources/code/html_javascript/fpsr_demo.html
@@ -582,7 +582,7 @@
 
                 // --- BD Params ---
                 globalParams.bd = {
-                    blockSize: parseBigIntInput('bd_blockSize', 64n),
+                    blockSize: parseBigIntInput('bd_blockSize', 60n),
                     streamsNumber: parseIntInput('bd_streamsNumber', 3),
                     streamsOffset: parseBigIntInput('bd_streamsOffset', 10n),
                     intraOp: document.getElementById('bd_intraOp').value,


### PR DESCRIPTION
Tightens the formatting of the FPSR visualiser benchmark table by removing an extra space before the Bitwise Decode performance value.

Update the BD parameter defaults in `fpsr_demo.html` by changing `blockSize` from `64n` to `60n`, so the demo initializes with the intended block size value.