### PR TITLE
Refine playback speed control and metrics

### DIFF
--- a/resources/code/html_javascript/benchmmarks/fpsr_visualiser_metrics.md
+++ b/resources/code/html_javascript/benchmmarks/fpsr_visualiser_metrics.md
@@ -89,7 +89,7 @@ Version 153.0.3 (64-bit)
 | Stacked Modulo | ~1, 060 k/s |
 | Toggled Modulo | ~1, 750 k/s |
 | Quantised Switching | ~660 k/s |
-| Bitwise Decode (default 3 streams, blocksize 64) | ~340 k/s |
+| Bitwise Decode (default 3 streams, blocksize 64) | ~352 k/s |
 
 ### BD Breakdown by Streams and Blocksize
 | Streams | Blocksize | Approximate Performance |
@@ -98,12 +98,12 @@ Version 153.0.3 (64-bit)
 |   | 60 | ~605 k/s |
 | 2 | 30 | ~435 k/s |
 |   | 60 | ~440 k/s |
-| 3 | 30 | ~328 k/s |
-|   | 60 | ~340 k/s |
-| 4 | 30 | ~295 k/s |
-|   | 60 | ~283 k/s |
-| 7 | 30 | ~170 k/s |
-|   | 60 | ~157 k/s |
+| 3 | 30 | ~371 k/s |
+|   | 60 | ~352 k/s |
+| 4 | 30 | ~309 k/s |
+|   | 60 | ~301 k/s |
+| 7 | 30 | ~178 k/s |
+|   | 60 | ~170 k/s |
 
 ---
 ## Android Phone Specifications

--- a/resources/code/html_javascript/fpsr_demo.html
+++ b/resources/code/html_javascript/fpsr_demo.html
@@ -348,8 +348,8 @@
                     <div class="param-group" title="Global playback speed. < 1.0 = Slow-Motion (Stretch), > 1.0 = Fast-Motion (Compress)">
                         <label for="global_frameMultiplier">Playback Speed (frame_multiplier)</label>
                         <div class="flex items-center space-x-2">
-                            <input id="global_frameMultiplier" type="range" min="0.1" max="4.0" value="1.0" step="0.05" class="w-full">
-                            <span id="global_frameMultiplierValue" class="text-sm text-white w-12 text-right">1.00x</span>
+                            <input id="global_frameMultiplier" type="range" min="0.1" max="4.0" value="1.0" step="0.01" class="w-full">
+                            <input id="global_frameMultiplierInput" type="number" min="0.01" step="0.01" value="1.00" class="w-20 bg-gray-700 text-white border-gray-600 rounded-md p-1 text-xs text-center font-mono">
                             <!-- *** Reset Button *** -->
                             <button id="resetFrameMultiplierButton" class="bg-gray-600 hover:bg-gray-700 text-white font-bold py-1 px-2 rounded-md text-xs transition duration-150" title="Reset to 1.0x">
                                 1.0x
@@ -419,7 +419,7 @@
             
             // --- New Global HPQ UI ---
             const frameMultiplierSlider = document.getElementById('global_frameMultiplier');
-            const frameMultiplierValue = document.getElementById('global_frameMultiplierValue');
+            const frameMultiplierInput = document.getElementById('global_frameMultiplierInput');
             const resetFrameMultiplierButton = document.getElementById('resetFrameMultiplierButton'); // NEW
 
             // --- Scroll Speed UI Elements ---
@@ -467,41 +467,22 @@
                 const valueSpan = document.getElementById(slider.id + 'Value');
                 if (valueSpan) {
                     slider.addEventListener('input', (e) => {
-                        let currentValue = parseFloat(e.target.value);
-
-                        if (slider.id === 'global_frameMultiplier') {
-                            
-                            // --- Snap Logic ---
-                            const snapThreshold = 0.05; // Snap if within this range
-                            const snapIncrement = 0.25;
-                            const remainder = currentValue % snapIncrement;
-                            
-                            // Snap to increments of 0.25
-                            // Check if close to the low end (e.g., 0.28 -> 0.25)
-                            if (remainder < snapThreshold) {
-                                currentValue = Math.floor(currentValue / snapIncrement) * snapIncrement;
-                            } 
-                            // Check if close to the high end (e.g., 0.48 -> 0.50)
-                            else if ((snapIncrement - remainder) < snapThreshold) {
-                                currentValue = Math.ceil(currentValue / snapIncrement) * snapIncrement;
-                            }
-                            
-                            // Handle edge case for 0.1 min
-                            if (currentValue < 0.25 && currentValue > 0.1) currentValue = 0.25;
-                            
-                            // Special hard-snap for 1.0
-                            if (Math.abs(currentValue - 1.0) < snapThreshold) {
-                                currentValue = 1.0;
-                            }
-                            
-                            e.target.value = currentValue.toString();
-                            valueSpan.textContent = currentValue.toFixed(2) + 'x';
-                            // --- End Snap Logic ---
-
-                        } else {
-                            valueSpan.textContent = e.target.value;
-                        }
+                        valueSpan.textContent = e.target.value;
                     });
+                }
+            });
+
+            // Sync Playback Speed slider and numeric input
+            frameMultiplierSlider.addEventListener('input', (e) => {
+                frameMultiplierInput.value = parseFloat(e.target.value).toFixed(2);
+                updateParams();
+            });
+
+            frameMultiplierInput.addEventListener('input', (e) => {
+                const val = parseFloat(e.target.value);
+                if (!isNaN(val)) {
+                    frameMultiplierSlider.value = val;
+                    updateParams();
                 }
             });
 
@@ -529,7 +510,7 @@
             // --- Params Update Function ---
             function updateParams() {
                 // --- Read Global HPQ Params ---
-                globalParams.frameMultiplier = parseFloatInput('global_frameMultiplier', 1.0);
+                globalParams.frameMultiplier = parseFloatInput('global_frameMultiplierInput', 1.0);
                 globalParams.segBlockLength = parseIntInput('global_segBlockLength', 5);
 
                 // --- SM Params ---
@@ -638,6 +619,7 @@ allTabs.forEach(tab => {
                     // 2. Disable Global HPQ Time Controls in Legacy Mode
                     const hpqSection = document.getElementById('global_frameMultiplier').closest('.mt-6');
                     frameMultiplierSlider.disabled = isLegacy;
+                    frameMultiplierInput.disabled = isLegacy;
                     resetFrameMultiplierButton.disabled = isLegacy;
                     document.getElementById('global_segBlockLength').disabled = isLegacy;
 
@@ -666,7 +648,7 @@ allTabs.forEach(tab => {
                 
                 // Reset global controls
                 document.getElementById('global_frameMultiplier').value = 1.0;
-                document.getElementById('global_frameMultiplierValue').textContent = "1.00x";
+                document.getElementById('global_frameMultiplierInput').value = "1.00";
                 document.getElementById('global_segBlockLength').value = 5;
 
                 updateParams();
@@ -772,12 +754,9 @@ allTabs.forEach(tab => {
             // --- Reset Frame Multiplier Button ---
             resetFrameMultiplierButton.addEventListener('click', () => {
                 frameMultiplierSlider.value = "1.0";
-                frameMultiplierValue.textContent = "1.00x";
-                // Manually trigger the 'input' event on the slider to update params
-                // and reset the simulation, just like updateParams() does.
-                frameMultiplierSlider.dispatchEvent(new Event('input'));
+                frameMultiplierInput.value = "1.00";
+                updateParams();
             });
-
 
 
             // --- Core FPS-R Logic (64-bit BigInt Port) ---


### PR DESCRIPTION
Replace the playback speed readout with a synced numeric input, increase slider precision, and keep legacy/reset behavior aligned with the new control. Also refresh the visualiser benchmark document with improved bitwise decode performance figures.